### PR TITLE
Update notebook.js.es6: DEV: Discourse.Route has been deprecated

### DIFF
--- a/assets/javascripts/discourse/routes/notebook.js.es6
+++ b/assets/javascripts/discourse/routes/notebook.js.es6
@@ -1,9 +1,10 @@
 /**
  * Route for the path `/notebook` as defined in `../notebook-route-map.js.es6`.
  */
-export default Discourse.Route.extend({
+import DiscourseRoute from "discourse/routes/discourse";
+export default DiscourseRoute.extend({
   renderTemplate() {
     // Renders the template `../templates/notebook.hbs`
-    this.render('notebook');
-  }
+    this.render("notebook");
+  },
 });


### PR DESCRIPTION
This change fixes the issue with the issue "DEV: Discourse.Route has been deprecated" 

https://review.discourse.org/t/dev-discourse-route-has-been-deprecated/11668