### PR TITLE
Fix for Ember 5

### DIFF
--- a/assets/javascripts/discourse/controllers/notebook.js.es6
+++ b/assets/javascripts/discourse/controllers/notebook.js.es6
@@ -1,3 +1,5 @@
+import Ember from 'ember';
+
 export default Ember.Controller.extend({
   init() {
     this._super();


### PR DESCRIPTION
Discourse is using Ember 5 now, which [no longer allows global access of Ember](https://deprecations.emberjs.com/v3.x/#toc_ember-global). Importing ember explicitly solves the problem on the latest Discourse.